### PR TITLE
Don't use super

### DIFF
--- a/src/parser/compile_context.rs
+++ b/src/parser/compile_context.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::ops::DerefMut;
-use super::string_table::StringTable;
+use parser::string_table::StringTable;
 
 // This type is the root to manage several subcomponents.
 // In later revisions it has a StringTable, a SymbolTable, an ErrorHandler and more

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,11 +1,11 @@
 use std::str::Chars;
 
-use ::util::is_any_of::*;
+use util::is_any_of::*;
 
-use super::token::*;
-use super::token_stream::TokenStream;
-use super::util::char_util::CharProperties;
-use super::compile_context::CompileContext;
+use parser::token::*;
+use parser::token_stream::TokenStream;
+use parser::util::char_util::CharProperties;
+use parser::compile_context::CompileContext;
 
 // This is the lexer implementation for the parser (that sadly doesn't exist yet).
 // I am fully aware of super-neat tools that can generate lexers and parser automatically,

--- a/src/parser/token_stream.rs
+++ b/src/parser/token_stream.rs
@@ -1,4 +1,4 @@
-pub use super::token::Token;
+pub use parser::token::Token;
 
 // Types like the Lexer implement this trait as they are iterators
 // over Tokens. Maybe it should be substituted simply with the Iterator<Token> trait.


### PR DESCRIPTION
Using the properly qualified name is better, imho.

I think this one is _slightly_ a matter of opinion, but I don't think that `super` is particularly idiomatic.
