### PR TITLE
Clean up argument parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,20 +3,20 @@ use std::env;
 pub mod util;
 pub mod parser;
 
-fn parse_arguments() {
-    let args = env::args().collect::<Vec<_>>();
-    if args.len() > 1 {
-        println!("The first argument is {}", args[1]);
-        match args[1].parse::<i32>() {
-            Ok(n) => println!("{} is a valid number!", n),
-            Err(_) => println!("The first argument is not a number."),
-        };
-        let i = args[1].parse::<i32>().unwrap_or(0);
-        println!("Parsed first argument is {}", i);
+fn parse_arguments() -> Result<i32, String> {
+    let args = env::args().skip(1).next();
+
+    match args {
+        Some(s) => Ok(s.parse().unwrap_or(0)),
+        None => Err(String::from("Not enough arguments")),
     }
-    // println!("{}", is_double("5.0"));
 }
 
 fn main() {
-    parse_arguments();
+    let arg = match parse_arguments() {
+        Ok(arg) => arg,
+        Err(e) => panic!("There was an error parsing arguments: {}", e),
+    };
+
+    println!("Parsed first argument is {}", arg);
 }


### PR DESCRIPTION
So, this is a cleaned up version of the argument parsing code. When you're only looking for one argument, you might not even want it in an external function; but I wanted to show you how I'd do it in an external function too.
